### PR TITLE
Reintroduced Warning Feature in Program Lists

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 SnakeMD==0.12.1
-subete~=0.13.0
+subete~=0.14.0
 pytest==6.2.4
 pytest-cov==2.12.1
 setuptools~=57.0.0

--- a/ronbun/readme.py
+++ b/ronbun/readme.py
@@ -68,7 +68,7 @@ def _generate_program_list(language: LanguageCollection) -> list:
         program_line = Paragraph([f":white_check_mark: {program_name} [Requirements]"]) \
             .insert_link(program_name, program.documentation_url()) \
             .insert_link("Requirements", program.project().requirements_url())
-        if not program_line.verify_urls()[program.documentation_url()]:
+        if not program.has_docs():
             program_line.replace(":white_check_mark:", ":warning:") \
                 .replace_link(program.documentation_url(), program.article_issue_query_url())
         list_items.append(program_line)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="ronbun",
-    version="0.5.0",
+    version="0.6.0",
     author="The Renegade Coder",
     author_email="jeremy.grifski@therenegadecoder.com",
     description="The Sample Programs README Automation Tool",


### PR DESCRIPTION
Programs that did not have documentation used to show as warnings in the README. This broke once a page was created for every program in the repo. However, it would still be nice to differentiate documented code from undocumented code. 